### PR TITLE
Change reconnection logic to improve reliability

### DIFF
--- a/pyhon/connection/mqtt.py
+++ b/pyhon/connection/mqtt.py
@@ -53,7 +53,8 @@ class MQTTClient:
         if not lifecycle_connect_success_data.negotiated_settings.rejoined_session:
             # Resubscribe to all topics after reconnection
             # This is needed because we use a new client_id each time (no session persistence)
-            self._subscribe_appliances()
+            loop = asyncio.get_running_loop()
+            loop.run_in_executor(None, MQTTClient._subscribe_appliances, self)
         else:
             _LOGGER.info("Rejoined existing session")
 

--- a/pyhon/connection/mqtt.py
+++ b/pyhon/connection/mqtt.py
@@ -24,6 +24,7 @@ class MQTTClient:
         self._api = hon.api
         self._appliances = hon.appliances
         self._connection = False
+        self._subscribed = False
         self._watchdog_task: asyncio.Task[None] | None = None
 
     @property
@@ -53,8 +54,8 @@ class MQTTClient:
         if not lifecycle_connect_success_data.negotiated_settings.rejoined_session:
             # Resubscribe to all topics after reconnection
             # This is needed because we use a new client_id each time (no session persistence)
-            loop = asyncio.get_running_loop()
-            loop.run_in_executor(None, MQTTClient._subscribe_appliances, self)
+            _LOGGER.info("MQTT connection established, marking as not subscribed")
+            self._subscribed = False
         else:
             _LOGGER.info("Rejoined existing session")
 
@@ -134,8 +135,13 @@ class MQTTClient:
         )
 
     def _subscribe_appliances(self) -> None:
-        for appliance in self._appliances:
-            self._subscribe(appliance)
+        try:
+            for appliance in self._appliances:
+                self._subscribe(appliance)
+            self._subscribed = True
+        except Exception as e:
+            _LOGGER.error("Error subscribing to appliances: %s - %s", repr(e), str(e))
+
 
     def _subscribe(self, appliance: HonAppliance) -> None:
         for topic in appliance.info.get("topics", {}).get("subscribe", []):
@@ -154,3 +160,6 @@ class MQTTClient:
             if not self._connection:
                 _LOGGER.info("Restart mqtt connection")
                 await self._start()
+            elif not self._subscribed:
+                _LOGGER.info("Resubscribing to appliance topics")
+                self._subscribe_appliances()

--- a/pyhon/connection/mqtt.py
+++ b/pyhon/connection/mqtt.py
@@ -34,7 +34,6 @@ class MQTTClient:
 
     async def create(self) -> "MQTTClient":
         await self._start()
-        self._subscribe_appliances()
         await self.start_watchdog()
         return self
 
@@ -51,6 +50,12 @@ class MQTTClient:
         _LOGGER.info(
             "Lifecycle Connection Success: %s", str(lifecycle_connect_success_data)
         )
+        if not lifecycle_connect_success_data.negotiated_settings.rejoined_session:
+            # Resubscribe to all topics after reconnection
+            # This is needed because we use a new client_id each time (no session persistence)
+            self._subscribe_appliances()
+        else:
+            _LOGGER.info("Rejoined existing session")
 
     def _on_lifecycle_attempting_connect(
         self,
@@ -148,4 +153,3 @@ class MQTTClient:
             if not self._connection:
                 _LOGGER.info("Restart mqtt connection")
                 await self._start()
-                self._subscribe_appliances()


### PR DESCRIPTION
This should increase reliability of the MQTT connection.

I often notice it loses connection for a tiny bit, then reconnects, but it looks like this might be on haier's side as the subscriptions are lost at this point so no data is received after this point.

To resolve this I moved the subscribe appliances to the on connected hook and check if it's a new session or an older session.

I validated when it's a rejoined session and in my case basically never, so it's always needed to resubscribe but that isn't done at the moment.