### PR TITLE
Always add default value to enum values

### DIFF
--- a/pyhon/parameter/enum.py
+++ b/pyhon/parameter/enum.py
@@ -1,7 +1,10 @@
+import logging
+
 from typing import Dict, Any, List
 
 from pyhon.parameter.base import HonParameter
 
+_LOGGER = logging.getLogger(__name__)
 
 def clean_value(value: str | float) -> str:
     return str(value).strip("[]").replace("|", "_").lower()
@@ -33,6 +36,11 @@ class HonParameterEnum(HonParameter):
     @values.setter
     def values(self, values: List[str]) -> None:
         self._values = values
+        if self._default and clean_value(self._default.strip("[]")) not in self.values:
+            self._values.append(self._default)
+        _LOGGER.info(
+            "Set values of %s to %s", str(self._key), str(self._values)
+        )
 
     @property
     def intern_value(self) -> str:


### PR DESCRIPTION
Added logging to track changes in values and default handling to hopefully fix the "allowed values" error.

The way I got to this fix is by noticing that defaultValue isn't defined anywhere, so should always be zero, but the defaultValue is somehow not in the values array, so as such I can conclude that the values are overriden elsewhere after initializing the enum value.
And instead of searching endlessly for the source I think this is the most realiable and easy solution to that issue.