### PR TITLE
Fix per-request CIAM re-login and send x-api-key on auth requests

### DIFF
--- a/pyhon/connection/handler/auth.py
+++ b/pyhon/connection/handler/auth.py
@@ -14,7 +14,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class HonAuthConnectionHandler(ConnectionHandler):
-    _HEADERS = {"user-agent": const.USER_AGENT}
+    _HEADERS = {"user-agent": const.USER_AGENT, "x-api-key": const.API_KEY}
 
     def __init__(self, session: Optional[aiohttp.ClientSession] = None) -> None:
         super().__init__(session)

--- a/pyhon/connection/handler/hon.py
+++ b/pyhon/connection/handler/hon.py
@@ -58,10 +58,10 @@ class HonConnectionHandler(ConnectionHandler):
         return self
 
     async def _check_headers(self, headers: Dict[str, str]) -> Dict[str, str]:
-        if self._refresh_token:
-            await self.auth.refresh(self._refresh_token)
         if not (self.auth.cognito_token and self.auth.id_token):
             await self.auth.authenticate()
+        elif self.auth.token_expires_soon:
+            await self.auth.refresh(self._refresh_token)
         self._refresh_token = self.auth.refresh_token
         headers["cognito-token"] = self.auth.cognito_token
         headers["id-token"] = self.auth.id_token


### PR DESCRIPTION
Follow-up to #7. Two fixes reported after that PR was merged.

## Problem
After #7, a user saw repeated `401 - Invalid username or password` errors with correct credentials, after an initially working login.

Root cause: `_get_tokens()` stores a `refresh_token` when the CIAM response contains one, and `_check_headers()` then called `refresh()` on **every** request whenever `_refresh_token` was set. Since `refresh()` does a full CIAM re-login, this triggered a full `/ciam/authorize` call per API request, which Haier rate-limits/locks, surfacing as `401 Invalid username or password`.

## Changes
- **`_check_headers()`**: only authenticate when there is no token, and only refresh when the token is near expiry. The 401/403 retry path in `_intercept()` is unchanged.
- **Auth handler headers**: send `x-api-key` (alongside `user-agent`) on the CIAM auth requests, matching the main API handler.

## Validation
- `black`, `flake8`, `mypy` all clean.
- Confirmed in the field by another user running these changes (stable for a full day).

Thanks to the GPT-5.5 review comment on #7 and jfmcarreira/pyhon@d6ada53 for confirming the fix.