### PR TITLE
Fix favourite parameter handling: shared state + ignored per-favourite overrides

### DIFF
--- a/pyhon/command_loader.py
+++ b/pyhon/command_loader.py
@@ -188,6 +188,17 @@ class HonCommandLoader:
             if not base:
                 continue
             base_command: HonCommand = copy(base)
+            # `copy()` only shallow-copies the HonCommand: base_command.parameters
+            # would still be the *same* dict, holding the *same* parameter objects,
+            # as base.parameters. Every subsequent mutation below (favourite-specific
+            # overrides, the "favourite" marker, the program name) would then silently
+            # leak back into `base` and into every other favourite derived from the
+            # same base program - which is exactly why selecting one favourite could
+            # make the program name (or other settings) of an unrelated one change too.
+            # Give this favourite its own independent parameter objects instead.
+            base_command._parameters = {
+                key: copy(parameter) for key, parameter in base.parameters.items()
+            }
             self._update_base_command_with_data(base_command, favourite)
             self._update_base_command_with_favourite(base_command)
             self._update_program_categories(command_name, name, base_command)
@@ -208,7 +219,24 @@ class HonCommandLoader:
         for data in command.values():
             if isinstance(data, str):
                 continue
+            # Haier nests the actual per-favourite override values (e.g.
+            # dirtyLevel, temp, spinSpeed) one level deeper, inside
+            # data["parameters"], not directly in `data` itself. Without this,
+            # every favourite built from the same base program (e.g. all
+            # "resistant_cotton" favourites) silently kept the base program's
+            # generic default temp/dirtyLevel/etc. instead of its own saved
+            # values - selecting different favourites appeared to have no
+            # effect on these settings at all.
+            for key, value in data.get("parameters", {}).items():
+                if not (parameter := base_command.parameters.get(key)):
+                    continue
+                with suppress(ValueError):
+                    parameter.value = value
+            # Keep the previous (shallow) behaviour too, in case a caller
+            # ever passes an already-flattened dict.
             for key, value in data.items():
+                if isinstance(value, dict):
+                    continue
                 if not (parameter := base_command.parameters.get(key)):
                     continue
                 with suppress(ValueError):


### PR DESCRIPTION
Two related bugs in HonCommandLoader._add_favourites():

1. copy(base) only shallow-copies HonCommand - base_command.parameters
   stayed the same dict/objects as base.parameters, so mutating one
   favourite leaked into the base program and every other favourite
   sharing it (e.g. selecting one favourite could silently change an
   unrelated favourite's program name).

2. _update_base_command_with_data only read one level into the
   favourite dict (favourite['command']), never favourite['command']['parameters'],
   which is where Haier actually nests dirtyLevel/temp/spinSpeed/etc.
   Result: every favourite based on the same program silently used the
   program's generic default settings instead of its own saved values.

Tested against a real hOn washing machine account with multiple
favourites sharing base programs (resistant_cotton, all_in_one_59).
